### PR TITLE
Fix p4 qos scheduler query

### DIFF
--- a/switchsai/src/saiport.c
+++ b/switchsai/src/saiport.c
@@ -251,6 +251,9 @@ sai_status_t sai_get_port_attribute(
            case SAI_PORT_ATTR_QOS_NUMBER_OF_QUEUES:
                 attr->value.u32list.count = 0;
                 break;
+           case SAI_PORT_ATTR_QOS_NUMBER_OF_SCHEDULER_GROUPS:
+               attr->value.u32list.count = 0;
+               break;
            default:
                status = SAI_STATUS_NOT_SUPPORTED;
                break;


### PR DESCRIPTION
Add support to query SAI_PORT_ATTR_QOS_NUMBER_OF_SCHEDULER_GROUPS. 